### PR TITLE
Adding build-tools-24.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH ${ANDROID_HOME}/tools:$ANDROID_HOME/platform-tools:$PATH
 # Install Android SDK components
 
 # License Id: android-sdk-license-ed0d0a5b
-ENV ANDROID_COMPONENTS platform-tools,build-tools-23.0.3,build-tools-24.0.0,android-23,android-24
+ENV ANDROID_COMPONENTS platform-tools,build-tools-23.0.3,build-tools-24.0.0,build-tools-24.0.2,android-23,android-24
 # License Id: android-sdk-license-5be876d5
 ENV GOOGLE_COMPONENTS extra-android-m2repository,extra-google-m2repository
 


### PR DESCRIPTION
`build-tools-24.0.2` is the latest version, so I added.
Also I believe it should be considered to add multiple versions of it, since many projects are not always fully up to date. (That's why I didn't replace 24.0.0)
Let me know what you think, and I'll update this PR.
