### PR TITLE
Use openjdk:8 base image instead of java:8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # based on https://registry.hub.docker.com/u/samtstern/android-sdk/dockerfile/ with openjdk-8
-FROM java:8
+FROM openjava:8
 
 MAINTAINER FUJI Goro <g.psy.va+github@gmail.com>
 


### PR DESCRIPTION
The `java` base image is deprecated in favor of the `openjdk` image. They are in fact the same image, but `java` images wont be updated after 2016-12-31
